### PR TITLE
refactor: api naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Wortal.showInterstitial(Placement.NEXT, 'NextLevel', pauseGame, resumeGame);
 Calling for rewarded ads is similar to interstitials, but with more callbacks:
 
 ```typescript
-Wortal.requestRewarded(description, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback);
+Wortal.showRewarded(description, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback);
 
 // Example:
-Wortal.requestRewarded('ReviveAndContinue', pauseGame, resumeGame, noReward, rewardPlayer);
+Wortal.showRewarded('ReviveAndContinue', pauseGame, resumeGame, noReward, rewardPlayer);
 ```
 
 ## Building

--- a/static/template/default/index.html
+++ b/static/template/default/index.html
@@ -38,13 +38,13 @@
     <div class="infobox">
         <p>
             <code>
-                Wortal.requestRewarded(description, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback);
+                Wortal.showRewarded(description, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback);
             </code>
             <br/>
             <code>
                 // Example:
                 <br/>
-                Wortal.requestRewarded('ReviveAndContinue', pauseGame, resumeGame, noReward, rewardPlayer);
+                Wortal.showRewarded('ReviveAndContinue', pauseGame, resumeGame, noReward, rewardPlayer);
             </code>
         </p>
     </div>


### PR DESCRIPTION
* Use consistent ad call API naming across SDK
* Follow language style convention