### PR TITLE
fix: incorrect path when downloaded from Cocos Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2022-09-01
+### Fixed
+- Incorrect extension path when downloading from Cocos Store
+
 ## [1.0.6] - 2022-08-31
 ### Added
 - Demo scene and script

--- a/dist/main.js
+++ b/dist/main.js
@@ -7,7 +7,7 @@ exports.unload = exports.load = void 0;
 const fs_extra_1 = require("fs-extra");
 const compare_versions_1 = require("compare-versions");
 const path_1 = __importDefault(require("path"));
-const PACKAGE_NAME = 'wortal-sdk';
+const PACKAGE_NAME = 'Wortal';
 exports.load = () => {
     function log(...arg) {
         return console.log(`[${PACKAGE_NAME}] `, ...arg);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "package_version": 2,
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "wortal-sdk",
     "title": "i18n:wortal-sdk.title",
     "description": "i18n:wortal-sdk.description",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import {copySync, pathExistsSync} from 'fs-extra';
 import {compare} from 'compare-versions';
 import path from 'path';
 
-const PACKAGE_NAME = 'wortal-sdk';
+const PACKAGE_NAME = 'Wortal';
 
 export const load: BuildPlugin.load = () => {
     function log(...arg: any[]) {


### PR DESCRIPTION
The package is named `wortal-sdk` but when downloaded from the Cocos Store it is installed to the path of the store resource name, which is `Wortal`.