### PR TITLE
feat: add support for installing from store and local resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] - 2022-09-01
+### Added
+- Support for Cocos Store installation or local
+
 ## [1.0.7] - 2022-09-01
 ### Fixed
 - Incorrect extension path when downloading from Cocos Store

--- a/dist/main.js
+++ b/dist/main.js
@@ -7,7 +7,8 @@ exports.unload = exports.load = void 0;
 const fs_extra_1 = require("fs-extra");
 const compare_versions_1 = require("compare-versions");
 const path_1 = __importDefault(require("path"));
-const PACKAGE_NAME = 'Wortal';
+const fs_1 = require("fs");
+let PACKAGE_NAME = 'Wortal';
 exports.load = () => {
     function log(...arg) {
         return console.log(`[${PACKAGE_NAME}] `, ...arg);
@@ -24,6 +25,10 @@ exports.load = () => {
     const demo_dir = "wortal-demo";
     let version = "";
     let editor = Editor.App.version;
+    if (!fs_1.existsSync(path_1.default.join(project_path, "extensions/" + PACKAGE_NAME))) {
+        log("Package not downloaded from Cocos Store, changing extension directory..");
+        PACKAGE_NAME = "wortal-sdk";
+    }
     log("Detected editor version: " + editor);
     // Versions 3.0.0 - 3.5.2 should use the 3.0 templates. 3.6+ uses the 3.6 template.
     // This is due to major changes in the build template starting in 3.6.0.
@@ -36,7 +41,7 @@ exports.load = () => {
     else {
         error("Version not supported: " + editor);
     }
-    const static_templates = path_1.default.join(Editor.Project.path, "extensions/" + PACKAGE_NAME + "/templates/");
+    const static_templates = path_1.default.join(project_path, "extensions/" + PACKAGE_NAME + "/templates/");
     const versioned_templates = path_1.default.join(static_templates + version + "/");
     const assets = [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "package_version": 2,
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "wortal-sdk",
     "title": "i18n:wortal-sdk.title",
     "description": "i18n:wortal-sdk.description",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,9 @@ import {BuildPlugin} from '../@types';
 import {copySync, pathExistsSync} from 'fs-extra';
 import {compare} from 'compare-versions';
 import path from 'path';
+import {existsSync} from "fs";
 
-const PACKAGE_NAME = 'Wortal';
+let PACKAGE_NAME = 'Wortal';
 
 export const load: BuildPlugin.load = () => {
     function log(...arg: any[]) {
@@ -24,6 +25,11 @@ export const load: BuildPlugin.load = () => {
     let version = "";
     let editor = Editor.App.version;
 
+    if (!existsSync(path.join(project_path, "extensions/" + PACKAGE_NAME))) {
+        log("Package not downloaded from Cocos Store, changing extension directory..");
+        PACKAGE_NAME = "wortal-sdk";
+    }
+
     log("Detected editor version: " + editor);
 
     // Versions 3.0.0 - 3.5.2 should use the 3.0 templates. 3.6+ uses the 3.6 template.
@@ -36,7 +42,7 @@ export const load: BuildPlugin.load = () => {
         error("Version not supported: " + editor);
     }
 
-    const static_templates = path.join(Editor.Project.path, "extensions/" + PACKAGE_NAME + "/templates/");
+    const static_templates = path.join(project_path, "extensions/" + PACKAGE_NAME + "/templates/");
     const versioned_templates = path.join(static_templates + version + "/");
 
     const assets = [


### PR DESCRIPTION
Extension now checks if the path is created from local resource or Cocos Store installation, as these will be different.