### PR TITLE
feat: add support for ad blockers

### DIFF
--- a/templates/wortal-api/Wortal.ts
+++ b/templates/wortal-api/Wortal.ts
@@ -7,6 +7,7 @@ export class Wortal {
     private static _platform: Platform;
     private static _gameName: string;
     private static _isInit: boolean = false;
+    private static _isAdBlocked: boolean = false;
 
     private static _linkInterstitialId: string;
     private static _linkRewardedId: string;
@@ -27,6 +28,9 @@ export class Wortal {
             console.warn("[Wortal] Already initialized");
             return;
         }
+
+        this._isAdBlocked = (window as any).isAdBlocked;
+        console.log("[Wortal] AdBlocker: " + this._isAdBlocked);
 
         Wortal._gameName = document.title;
         Wortal._platform = Wortal.getPlatform();
@@ -82,6 +86,12 @@ export class Wortal {
         if (!Wortal._isInit) {
             console.warn("[Wortal] SDK not initialized before ad call, ad may be skipped.");
             Wortal.init();
+        }
+
+        if (Wortal._isAdBlocked) {
+            console.warn("[Wortal] Ads are blocked. Calling afterAd().");
+            afterAd();
+            return;
         }
 
         if (Wortal._isAdShowing) {
@@ -184,6 +194,12 @@ export class Wortal {
         if (!Wortal._isInit) {
             console.warn("[Wortal] SDK not initialized before ad call, ad may be skipped.");
             Wortal.init();
+        }
+
+        if (Wortal._isAdBlocked) {
+            console.warn("[Wortal] Ads are blocked. Calling afterAd().");
+            afterAd();
+            return;
         }
 
         if (Wortal._isAdShowing) {

--- a/templates/wortal-bridge/wortal-init.js
+++ b/templates/wortal-bridge/wortal-init.js
@@ -1,3 +1,4 @@
+var isAdBlocked = false;
 let platform = window.getWortalPlatform();
 console.log('[Wortal] Platform: ' + platform);
 
@@ -24,6 +25,10 @@ window.addEventListener("load", () => {
             });
         }
         console.log("[Wortal] Initialized.");
+    }, function () {
+        console.log("[Wortal] Ad blocker detected.");
+        _removeLoadingCover();
+        isAdBlocked = true;
     });
 });
 


### PR DESCRIPTION
This PR adds support for ad blockers. Previously games would stop on the loading screen if the preroll ad was not able to be shown. Wortal now detects if an ad blocker is present and continues to load the game normally.