### PR TITLE
fix: missing script in demo scene

### DIFF
--- a/2.x/templates/wortal-demo/NOTE.txt
+++ b/2.x/templates/wortal-demo/NOTE.txt
@@ -1,0 +1,7 @@
+The demo will initially show warnings for a missing script on the Script_ButtonHandler node.
+This is possibly due to the UUID and/or class ID changing on import.
+
+To resolve this:
+1. Remove the missing script from Script_ButtonHandler
+2. Add Custom Component -> DemoButtonHandler
+3. Assign the references for the buttons


### PR DESCRIPTION
This PR adds a proposed fix for the missing script warning when loading the demo scene. The issue appears to be with Cocos assigning a different UUID and/or script ID to the `DemoButtonHandler` script after it is copied into the project. Including meta files in the package didn't appear to resolve this.

Since this is a trivial issue that does not affect the functionality of the SDK itself, I've just included a note in the demo directory that gives the steps needed to fix this issue if the user wants to view the demo in the editor. This is not really necessary as the demo is meant to show how to use the SDK in code, rather than via editor assignments.